### PR TITLE
Increase volume space

### DIFF
--- a/deploy-as-code/helm/environments/ukd-prod-sdc.yaml
+++ b/deploy-as-code/helm/environments/ukd-prod-sdc.yaml
@@ -812,7 +812,7 @@ elasticsearch-data-infra-v1:
      - iqn.2010-06.com.nutanix:kubernete-production-f5f97b7d-e904-4a28-b57a-d88bef648b53-tgt24
      - iqn.2010-06.com.nutanix:kubernete-production-f5f97b7d-e904-4a28-b57a-d88bef648b53-tgt25
   replicas: 2
-  storage-size: 100Gi  
+  storage-size: 150Gi  
   images:
     - docker.elastic.co/elasticsearch/elasticsearch-oss:6.6.2
   network-host: "_eth0:ipv4_" 


### PR DESCRIPTION
increase Elasticsearch-data-infra-v1 volume space 100gb to 150 gb