### PR TITLE
[DPG-959] Added chart config because request is failing for large file

### DIFF
--- a/deploy-as-code/helm/charts/core-services/egov-filestore/values.yaml
+++ b/deploy-as-code/helm/charts/core-services/egov-filestore/values.yaml
@@ -124,6 +124,8 @@ env: |
     value: {{ index .Values "heap" | quote }}
   - name: ALLOWED_FORMATS_MAP
     value: {{ index .Values "allowed-file-formats-map" | quote }}
+  - name: SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE
+    value: {{ index .Values "spring-servlet-multipart-max-request-size" | quote }}
   {{- if index .Values "filestore-url-validity" }}   
   - name: PRESIGNED_URL_EXPIRY_TIME_IN_SECS     
     value: {{ index .Values "filestore-url-validity" | quote }}   

--- a/deploy-as-code/helm/environments/uat.yaml
+++ b/deploy-as-code/helm/environments/uat.yaml
@@ -189,6 +189,7 @@ egov-filestore:
   allowed-file-formats-map: "{jpg:{'image/jpg','image/jpeg'},jpeg:{'image/jpeg','image/jpg'},png:{'image/png'},pdf:{'application/pdf'},odt:{'application/vnd.oasis.opendocument.text'},ods:{'application/vnd.oasis.opendocument.spreadsheet'},docx:{'application/x-tika-msoffice','application/x-tika-ooxml','application/vnd.oasis.opendocument.text','application/msword'},doc:{'application/x-tika-msoffice','application/x-tika-ooxml','application/vnd.oasis.opendocument.text','application/msword'},dxf:{'text/plain','application/dxf','application/octet-stream','image/vnd.dxf','image/vnd.dxf; format=ascii','image/vnd.dxf; format=binary','image/vnd.dxb'},csv:{'text/plain'},txt:{'text/plain'},xlsx:{'application/x-tika-ooxml','application/x-tika-msoffice','application/vnd.ms-excel'},xls:{'application/x-tika-ooxml','application/x-tika-msoffice','application/vnd.ms-excel'}}"
   allowed-file-formats: "jpg,jpeg,png,doc,docx,pdf,odt,ods,text,dxf,xls,xlsx"
   filestore-url-validity: 3600
+  spring-servlet-multipart-max-request-size: "40MB"
 
 egov-location:
   memory_limits: 512Mi


### PR DESCRIPTION
File upload requests are failing for larger file, 30MB is the default size in the egov-filestore service, so extending that to 40MB.