### PR TITLE
[DPG-959] Updating heap size for filestore

### DIFF
--- a/deploy-as-code/helm/environments/uat.yaml
+++ b/deploy-as-code/helm/environments/uat.yaml
@@ -190,6 +190,7 @@ egov-filestore:
   allowed-file-formats: "jpg,jpeg,png,doc,docx,pdf,odt,ods,text,dxf,xls,xlsx"
   filestore-url-validity: 3600
   spring-servlet-multipart-max-request-size: "70MB"
+  heap: "-Xmx512m -Xms512m"
 
 egov-location:
   memory_limits: 512Mi


### PR DESCRIPTION
Updating filestore heap size to 512MB because requests are failing.