### PR TITLE
[DPG-959] Updating memory size for filestore

### DIFF
--- a/deploy-as-code/helm/environments/uat.yaml
+++ b/deploy-as-code/helm/environments/uat.yaml
@@ -191,6 +191,7 @@ egov-filestore:
   filestore-url-validity: 3600
   spring-servlet-multipart-max-request-size: "70MB"
   heap: "-Xmx512m -Xms512m"
+  memory_limits: "768Mi"
 
 egov-location:
   memory_limits: 512Mi


### PR DESCRIPTION
Updating filestore memory size, because the server gets restarted.