### PR TITLE
Update persister path in audit-service helm

### DIFF
--- a/deploy-as-code/helm/environments/works-dev.yaml
+++ b/deploy-as-code/helm/environments/works-dev.yaml
@@ -223,7 +223,7 @@ works-inbox-service:
 #########---core-services---#########
 
 audit-service:
-  persist-yml-path: "file:///work-dir/works-configs/egov-persister/project-management-system-persister.yml"
+  persist-yml-path: "https://raw.githubusercontent.com/egovernments/works-configs/DEV/egov-persister/project-management-system-persister.yml"
   initContainers:
     gitSync:
       repo: "git@github.com:egovernments/works-configs"


### PR DESCRIPTION
- Persister path to be taken from remote instead of relative file path