### PR TITLE
Updated memory_limit of boundary-service to 512

### DIFF
--- a/deploy-as-code/helm/environments/unified-dev.yaml
+++ b/deploy-as-code/helm/environments/unified-dev.yaml
@@ -237,6 +237,9 @@ egov-idgen:
 mdms-v2:
    memory_limits: 512Mi
 
+boundary-service:
+  memory_limits: 512Mi
+
 egov-notification-sms:
   sms-provider-url: "sms provider url" ## Add sms provider url
   sms.provider.class: "Generic"


### PR DESCRIPTION
Set the memory_limit for boundary service to 512 MiB