### PR TITLE
feat(xstate-chatbot): Add xstate-chatbot configuration for unified-dev environment

### DIFF
--- a/deploy-as-code/helm/environments/unified-dev.yaml
+++ b/deploy-as-code/helm/environments/unified-dev.yaml
@@ -137,6 +137,7 @@ cluster-configs:
         noc-services: "http://noc-services.egov:8080/"
         minio-url: "https://minio-uat.digit.org/"
         egov-user-chatbot: "http://egov-user-chatbot:8080/"
+        xstate-chatbot: "http://xstate-chatbot.egov:8080/"
         zuul: "http://zuul:8080/"
         egov-url-shortening: "http://eus:8080/"
         fsm-calculator: "http://fsm-calculator.sanitation:8080/"
@@ -521,6 +522,23 @@ chatbot:
 
   user-service-chatbot-citizen-passwrord: "123456"
 
+xstate-chatbot:
+  replicas: 1
+  whatsapp-provider: "console"
+  contact-card-whatsapp-number: "+918744060444"
+  contact-card-whatsapp-name: "mSeva Punjab"
+  valuefirst-whatsapp-number: "918744060444"
+  valuefirst-notification-assigned-templateid: "205987"
+  valuefirst-notification-resolved-templateid: "205989"
+  valuefirst-notification-rejected-templateid: "205991"
+  valuefirst-notification-reassigned-templateid: "205993"
+  valuefirst-notification-commented-templateid: "205995"
+  valuefirst-notification-welcome-templateid: "205999"
+  valuefirst-notification-root-templateid: "206001"
+  valuefirst-send-message-url: "https://api.myvaluefirst.com/psms/servlet/psms.JsonEservice"
+  bill-supported-modules: "WS, PT, TL, FIRENOC, BPA"
+  pgr-version: "v2"
+  pgr-update-topic: "update-pgr-request"
 
 ws-services:
   wcid-format: "WS/[CITY.CODE]/[fy:yyyy-yy]/[SEQ_EGOV_COMMON]"


### PR DESCRIPTION
## Summary
- Added xstate-chatbot service host to egov-service-host configmap
- Added xstate-chatbot service configuration block for unified-dev environment
- Configuration includes WhatsApp provider settings, ValueFirst notification templates, PGR settings

## Configuration Details
- `whatsapp-provider`: "console" (for dev environment)
- `bill-supported-modules`: "WS, PT, TL, FIRENOC, BPA"
- `pgr-version`: "v2"

## Prerequisites Verified
✅ xstate-chatbot helm chart exists at `deploy-as-code/helm/charts/core-services/xstate-chatbot/`
✅ All required secrets already present in `unified-dev-secrets.yaml`:
  - `chatbot` (valuefirst-username, valuefirst-password)
  - `egov-user-chatbot` (citizen-login-password-otp-fixed-value)
  - `egov-location` (gmapskey)
  - `db` (username, password)

## Test plan
- [ ] Deploy xstate-chatbot service to unified-dev environment
- [ ] Verify service starts successfully
- [ ] Test WhatsApp webhook endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)