### PR TITLE
Updated unified-uat jenkins secrets to restrict access to deployments

### DIFF
--- a/deploy-as-code/helm/charts/backbone-services/jenkins/values.yaml
+++ b/deploy-as-code/helm/charts/backbone-services/jenkins/values.yaml
@@ -619,8 +619,8 @@ master:
                 }
                 disabled(false)
               }
-              {{- else if (eq $job.name "health-demo-upgrade") }}            
-              deployer(repo:'git@github.com:egovernments/health-campaign-devops.git', branch: 'health-demo-kubernetes-1.27', helmDir: 'config-as-code/helm', environment: '{{ $job.name }}')""")
+              {{- else if (eq $job.name "hcm-demo-new") }}            
+              deployer(repo:'git@github.com:egovernments/health-campaign-devops.git', branch: 'hcm-demo-new', helmDir: 'config-as-code/helm', environment: '{{ $job.name }}')""")
                       sandbox() 
                     }
                 }

--- a/deploy-as-code/helm/environments/ci-secrets.yaml
+++ b/deploy-as-code/helm/environments/ci-secrets.yaml
@@ -1324,38 +1324,38 @@ cluster-configs:
                                       value: ENC[AES256_GCM,data:j1CnYTIsQ3ZigwJzcdPBgoE+b02S24mHbw4ZO3/7BVLF8Ku7JojLDg==,iv:t6Vh3QlhItwjBfFEglj0sOIjQoXCvWF/MMKrENKa7ZQ=,tag:3V0bC0FtKB9ohCrHmfHrHA==,type:str]
                                     - name: ENC[AES256_GCM,data:QvtIFNQZfavb/A==,iv:1fr6X67GU1cTwxAARyEPrKVHdmiZvzgxSNyvTqHIInc=,tag:nty4UnEXg1kHJimO+iRLQQ==,type:str]
                                       value: ENC[AES256_GCM,data:CAqORKxl/Fr05Q==,iv:d5xoiSkiDDNltWKg+xGZi5Cl5MVpT9UV/+ONJSLNjl8=,tag:LHw9ZCXqYuWGWCggjRcvUw==,type:str]
-                health-demo-upgrade:
-                    apiVersion: ENC[AES256_GCM,data:trA=,iv:Z7pzYVuFs00aTcXqFVBsq9tsiMjNrGxV8RAgeuVAA+U=,tag:go5QF+Burn8UHycqVGmh+Q==,type:str]
+                hcm-demo-new:
+                    apiVersion: ENC[AES256_GCM,data:pGY=,iv:h9HIqnX12V5nHpx8ODMUr8w2EYRVSvTmnWk1aQQylSc=,tag:VWsKFByXcdMv5jJ/Q/C6Bg==,type:str]
                     clusters:
                         - cluster:
-                            certificate-authority-data: ENC[AES256_GCM,data:/bD8V7w7LZH5UrTOnZ1yQ+D9+avestRuF6/9PFksZwi/V77hNfkuZaALZuakZkWi1upfo8ueadeO8VRPd5uViawFLsvAya+2R5UGfkkOhpi9gM/NrtlAs+It2e5SASUwQ3S3RUei8zQ1pIr0LoxNWVAWK6BhIT5d+uRE9VYANMUeHI2Jyut5vnSHXsr6yaT2wmzN0u8Gks7WuW812zgHIrvYwx+ImS1gGNip9Y3FN+trogwKry7OQQc1ctGkh4Srkp1sSUQi1oPFZ84NmIENKJbcl8tEfDVweWNow35Y3xMoSCMi8NnGS+nIzwaDTG5lucptf1H8ApJhLB9hyuqZybNxtb+cvvP/WHnur4GJ6U19pP6xmd+TTETMIiAx0iLa7r41fsjUjhv7sUiCK4QTSYQTQ1QjiHoGQuprdknE0o+TnDg3u4nQF55cTZy1RGw9GLg15UY3HXrbeZ97qBnBluLwZd4c+sVc76Yg8J9rKNtrtcZallPXCkaWqsGntFXtA6RoqBprASWBVI6+IkOHkAF4zD/yKFMIp8V0ZAOTyjrIajHllJEsCRjI48H4JSBuglHz4ROY/Llec83cd34Y/3j1+1ovivVVbK2UTdxLc4erpOfg27isIRGbsU8ZAedJ9T1QJvGGjrGtnoORsRvTKUUfOwbs818TGQCiv19QcEebstFkBCFp0n8bryjDNsCeJa+ETb/cAzofA8ErlgpGaVbdUEu0NksCGZFThLbGPLlP1ED1vfBaIqUsJG6hj3BzTHnjUCZPCeHDsKez5kSPsh1gtGJcEiHjZEGmxe9YsZBPLl0xeM5ujmRJJu/LxyO8oQHQ338YntfPEkafR/QB9OaloMx4LMAeiquCoeiWFON69tXjPG5acTZeagNP2rld4KVbmfObk8Y+zsfgK+2FEgTQ+24mQU0oVBDjH9twTbboc1QFIsit/JT92cW6M9Tt7SSyWlapsFTofnWJ2d9BC6XwbHNO+IRXMGD53qnVCu0KjPTIDcTNT5RnPYBXOnr4htXBXbJqo5D6uvRG82R7EXg9sm7vo9Q9oIwPzd+rmFt88Mf+/BhOVnc2ictL3BZQT6uEr01MtF5pkuY0Le5vHwzFmX94jAa3b7QLO3ZJV/DFYDLxwWwFD9YEsrcFoU1tii+XA08ZvMI3HDAGBXjZcQcb0taaY3k5pr4eq2gzH4t36eEfgKQ2Xc24bprF0fe7EPB6wfUBLfeGcnuGaitMs4f1ZRYBLTO5MuovvQ3M0uWngBykFUed7auEvc4lgf914zogSCPvPAtcBDTg6UyIVRc0vefAT+AmjRJ3+am2R492A5dS9SnFkd/IP/aP4LcrACqgKSCtzphihluQe0LOTC1BULoYFGPq7gw0zOCKGUvmazXIG1jGRKw1P2LbrT0pYrfarbqi7FvfwpY9XM6aNoc2qkZmmnLFcBWvw3P00Nz7Reqmvj0G9CbOLfF/TVpVMOQmxETR2MT53Nh8OEm+CNfNC6K/wQxy7ShHSZJwKejHTj44IcP8wlzUc9gje3lISpFXNZN6aVKMFjuUWdIb1yootK+3tpxu+xKQCez9AgRD7d3lvPMIsqUGLHom3zJeq4Scw1UScRLquxSxdtnIIni44yee1LemJakgruV5O6RAWQy7WuGfY6sHKX0fBYEG4vzm7DZDuc/o4M4PpETHGKYUdeE7H6PDE1SZSOUkaOcqEj/91tVMDxQ593TniRWiSGS9QuNY9Z3IUXrdGk/zKkfWsRMrTHXv674IgscohKtULarRecSHLQ/ljs9WkgKIC4Cid7QM9Zn5Nlcsx2MkGN+2uxWM/NsjYR5W1jW8ghAw0JDHQuBrXr5PBqNgJRLe4lvL9XrrtGQj9+tupASumefQLWClrgllBArQtfkK5lHnRcA6W2PE7uM5Rk17Ut4vB1W6ngfbaw/yUhC5Qm0YBh8iZDZ/5ACQiFkd1TCv19R8GBDZ,iv:LqA+4xya7zOEiK+7o73whis9DJE5puZUU9n0xLBAqg8=,tag:AffIJzS+iWHzot9YvhK3xQ==,type:str]
-                            server: ENC[AES256_GCM,data:wbSPw7ONwBHFR2nCllS6ln7xubgxzPZFxXCZv9tekhkE/kYNmlS1X+5poHvzEPlN9IU9P5kdO3ZOxNDjVTiIM7EMfmoeebRN4Q==,iv:/2ScLtp3CvAL0fHoQ0mDEFGToVUSCZpyS2tOSS/N3ek=,tag:OsSNECedywiky5bIDNddnw==,type:str]
-                          name: ENC[AES256_GCM,data:rhMLwEPMQ+KdqgxNQA/v04+XpE3N,iv:X8pu/zsC4KvVi7sqVvewerx0+KlfOszVshMWFMdSYv4=,tag:xyjQ67ikRUj4ffrJSzZqLA==,type:str]
+                            certificate-authority-data: ENC[AES256_GCM,data:6Oa1muHatsfAK3sYBqz8wEuj8X4ETF2JIxJf1Xa0cBpQOFboMLcZ1hmPBNTSVJ9Ze99Yf1UBanDNoYvJykPdICLD7t5yJvQVfDgI+rDnjl90LgV5TNlhQoHdFzx2DYp/JUtCILUBuVLur/TRHTtcixvmnC61byWYQVoL22eTxTxET9+SRgXhA/IvquAGT9dFzROfbyBqSJaro4q49Ga79bociOXvs+quYIMjRqslEB5bIzXCqTtFjIPNU6kCSqR0ofmSSnCTjPhkc3AKJolq6AG33xmgqZlXD0DrcyShsjaINnG6eaEVyDw5iprDe6DNMOs00sk9N5heC2TvMz1rCnVjO+LS6ZkagiBe2BFrqEqhUsFz9bOwPUKd3U1Afaijd+cNvmS156tI0goYlGkZd09IyaCRBFhTi+N9Dm91cIK4CrotzaEnjGzSXz6Gn+9FREiJorqRJx2eJHeUtE3zhfW3yVZ7Fp+Df4qLZe7hQwAP6SRnGNEZfTbfl9AbrQ3bEJKwoFrWNiSxB2TaP5bSMkueJ6G7b4VcT0Uk0q6Nsl53mPjDjKGPYDnHP3vFYJAaY0W7XssRl3q8Ys87bu4PJfNMf4Ixs/ukM54oQAIpKMxdik3kHMWiUJOM9hiQ7rXwNLoP25z5rDXqzt4guxBXlKRg6NmZZ5yD0Xw2n/aOqMYcpZeR8z2iwzWNEYhyFx5YL75kEfvNQ8/qHVm3Fhbe0UVCHXi3x+8gslI+RNysjK3KKXTTFQEnKLw9+j5zoPgfWPVYhFKtw59aEG2pwbo7pMSo7Ru1Topnt9AxbjG6KkZuyapYB0z8bthIxZI/XdjZHlRjZVzyXVH3rpUAqoKjMI2SnRayje1VXeCN/snlv3Oy/xXhRbNyuMG6Ybj5P3ERi2vVPotzAf0vLxOT36AglNZWA2RuiSeqmKR9ERj7seXl+xOObducA2xHyydX3Usk8l/lWdP7mOyIIhPMVd7nj6y+EM18anqDJnZbs9TKceh7xiQFJwM0jg2QkAcdpuqmhM1vaOmpQy4XZyfLNFN1k9sU+xlI9dVhxpj3/Axesk2A9HqrOId06WU003W+3M2GysXAzjaKdLZwNriyfatiLkvt+7S7TCtZOfgqJEl6vfztQsKe9DXHwKEayFL8Ii1/vj4D0GxJDle+8t22XIH6o0Vfe3Uodg//QjTC5a8EUkXlYvffUHdDZQUzEmdJT6sgtjTHr/4Jt+1ToySyL4D9P6XhHk0B906q9OOunjG9cM62wNiSfHjev3jTeLNqmn2q95BF4cT+h3QZN5IN9d2qSjnyoxX/zfOS2xuT/G6XOVQmqd/ePaBJ9Qi8rXjgoA6P7qeclbncZveAr0568I/tx9fRy4qn8srW2b3KQ/Ne276t4IBxsfxUvFdXLqS00z8gs3mQlXf8bKtC/bk0d8uHs/rot2Q8QeQBGJd+WvpwFkytlmLmTKaqnj/tV9TSXZWVTX7b4WlY46fwUhkdIAWjWJfvNeQWkvcRuzrjvouyj5tqzjhJmSnL0ev52cpgzhZK6lMNsI8E2ObzEitQz+MFGOw56cGltpp0FxtFX4UAvjr+W6Go5t4hTw2ZbgTlIGqLNLuwGieewYkS+VyvsOZGE+KXsR2zjYf8aTNxrlkNidho9hWJXc26yn3Lr0psYIDXybBHGX7p0h58Hn+mJ3MR5hqm9Ecft4TySCxJoJ08jcBaFQTaGGzItEBT/btBLeGDw1Oq1TLHgloaipd0xKuW/ceInb+DNSjt6VGg4EyPROAiKo1yLFFXs4QbKo0+nVTpFFi4YAyFz9YHoqVTYRT4tgYbYUdB9KVLHp+IH1O5/CU/e/12N8pdUgRb1L8enXdoiTQa7477zNc2y2kxh2LF3mg9I/DuZsqGEe/kowrJXQADZv2Sw4dlGECDu8ZeGlIg/HAoOj82QAD5LxFTTad7ydr+Sa/Fd5GatBkZs2hqZoBr7f3f,iv:9ecMOv3cNRsB6mAjMK+mffbkxUh3U7Pf6ZK3OuydtgA=,tag:EIC6yKjEFg0vvczgLvjHbw==,type:str]
+                            server: ENC[AES256_GCM,data:5ccCDUJ5UG9BcY5LmjezM8V0dx2dEiTAdVabOEyzTjPq0IMjJmASnK7z6Xx1hifIs6WgwWOaMTs/6oyuIW8PzWBmiE/0hTG3uA==,iv:Ok0N/psVU6oPK9HqbsRxmLMYMjZ0Fb9G/kIog4h57aQ=,tag:I4VjEazG79s+PRC+oYMtAA==,type:str]
+                          name: ENC[AES256_GCM,data:JJEjYCvFr9IGbOwX,iv:/jKqq+6IDaWsPbakTkszyy3OKxcf8AzJilI1fu2TOds=,tag:VlgT5jmDjghy0HLwOk0NoA==,type:str]
                     contexts:
                         - context:
-                            cluster: ENC[AES256_GCM,data:I2MSbuZozYF1vFlraUBV8wNZXK+j,iv:iTWGzJn3kwm3Sf1fLb5T6KQIj/dJ8pDsnA+7sAsCDcA=,tag:0QBwW5rcfYsWVnyXghiIBQ==,type:str]
-                            user: ENC[AES256_GCM,data:/NpcEfRB84+pJ6Xf6GII6Dk2P54T,iv:BAVeJ4GDPhswh3yO44lxZjxMKDRRSUIZgEGKF4povFM=,tag:QH5VN0qXje535BR4Cfmb2Q==,type:str]
-                          name: ENC[AES256_GCM,data:gApc6fiL42Y8v/QbT5BjfRUQFRnq,iv:Kyy6n/Yw+Zc17i62qjXlDWpTrRYjvSR7i7ExlgjDshE=,tag:cgBs/eEu2N/8+cnoMioiiQ==,type:str]
-                    current-context: ENC[AES256_GCM,data:XsUoONfIyxoSYINzOmdkSjbt79yw,iv:jDDKbFs4u8Dcm4PeURnS4r4RhpNinpnpBY6NSBwa4IE=,tag:f2iV0pKJVu9/v7dlF5CAlA==,type:str]
-                    kind: ENC[AES256_GCM,data:MSQFrRmg,iv:lqYS0mkrHfrhxU7FayDRMeKXnwu48r0Np34m3eS8Y+o=,tag:GNZCHRpQOg6JsJuOMYHlZw==,type:str]
+                            cluster: ENC[AES256_GCM,data:9XQpVADNNLLIgWkU,iv:wABYApmj6lspmM/CcmHPMuLot4416ZKP36lFF7NlOAc=,tag:Nd4gEF8bE97Zxm8Fedo6bg==,type:str]
+                            user: ENC[AES256_GCM,data:7kkfd/+4eBvKVedh,iv:DjsouQ6TLvviU8JWH2VbQS35GCEEQlB5VNiaXPy/FeA=,tag:XV8RnqlJIfYjARwJbfOnhg==,type:str]
+                          name: ENC[AES256_GCM,data:WYX4rKqTYQhAUFJN,iv:sNcN6b5zPRGFETNRn09AfFbblB70hRFF4EdqltJ4mtQ=,tag:zZ8UHBD+yrArSxAWfQPMJw==,type:str]
+                    current-context: ENC[AES256_GCM,data:lB2YVWXzEzv9XCMQ,iv:+YhnLqdPeSQxlX+AIbdy7DykXmqTs6MAEmTeeIrtAvk=,tag:UlRSU8Du5my1X88HG0iHMw==,type:str]
+                    kind: ENC[AES256_GCM,data:LCwjEBxy,iv:gPjQVVCYhFSuNW9X/RP9ADRRsCVZGBVwA/T4+0k8/OY=,tag:Fb2Gs4fQyO+WQiyDr02XDg==,type:str]
                     preferences: {}
                     users:
-                        - name: ENC[AES256_GCM,data:Rqtsh/ngBLiYEJh95zhHDnyk66CZ,iv:MFSueJMjnRe3HZQbhHM1udS0LvXyHEzKRNbdRwuTfzE=,tag:5GkEGpDrOXgbg4b+3Y91OA==,type:str]
+                        - name: ENC[AES256_GCM,data:m2AS3kG+qAQZieVI,iv:8/tJZgKiPe74BptTHScQ6eeVuBNoUSJXdU4vDpUWsqI=,tag:qpAc6fDKDXY298J31lmnSw==,type:str]
                           user:
                             exec:
-                                apiVersion: ENC[AES256_GCM,data:rdakLLzMswHygyHAxrw/p5xLx5tAzO4pOdu7qFrdBVeAE0rNAg==,iv:CSTYdYKZkp9z57g6p1yg0eq4wnfMdPPa3TOAEdMx6Nw=,tag:T6avPyuHIqFTQvzIBI1JMQ==,type:str]
+                                apiVersion: ENC[AES256_GCM,data:ySKL+FQn/R9JRQFM+BfplK4GPo8503cyGPM6+jNmLRcPPp1ieQ==,iv:L5LG78VGoPvnUgiB7Hna0YOcCJrgT7MDnKZTuzdLiJw=,tag:A1HGZsnCpleXUvNLVGf0eA==,type:str]
                                 args:
-                                    - ENC[AES256_GCM,data:GdZvIwA=,iv:OlyTyycCGYA+Bwb7gVLHMCcvIQObKOU+mMmsVqDi9Lk=,tag:cmRcu1iXRiXHLDsoQi0sjA==,type:str]
-                                    - ENC[AES256_GCM,data:JN8=,iv:HXs6hsa2V8eIjnfWIENV280VJWC4O6S7/MwNKv9GKcY=,tag:TBi+XNqRB+iKt1KDVxfcFw==,type:str]
-                                    - ENC[AES256_GCM,data:7ll0Dc3CwHS4qVRfVkD12Ocjswhn,iv:O/a5RU07x9q5P6O7PksfSfJAQmycQC31z/JuZ6vPqNc=,tag:FDd2Rqa2+YXvWgVpTv40RQ==,type:str]
-                                command: ENC[AES256_GCM,data:0UXf7Bknh6IbqvB0OSXTNUahjtec,iv:xuYE7eJ2+3YegoUuVBPu6XBvluzg0KUk5mB6TPsCGr8=,tag:DfZiISuvk52avAY5QR12yw==,type:str]
+                                    - ENC[AES256_GCM,data:dCy3VJo=,iv:1Q/NegTVx14SSIXLFo5t8CarlHXCwMLioR+5RbV9EXM=,tag:RNaxRnZ/4XyDl/Ppis1mlQ==,type:str]
+                                    - ENC[AES256_GCM,data:IcA=,iv:f7N+g10W4MRvu1eXXkPUyI0bsDV6bga/xX8qR7ldmbY=,tag:LbHqq7fgEyXz2CBYVKVccw==,type:str]
+                                    - ENC[AES256_GCM,data:xLZUi7fur9wBLpRn,iv:GzcHEous4cAx2MMNTkESEPw8NsSK7UC0PTXYQ8BBvsA=,tag:cmL9HdcyRBdZV6VjeNOXAw==,type:str]
+                                command: ENC[AES256_GCM,data:11RFnPyAUfGtFNHkmj5tlHpgpuSt,iv:V3YGjI3cu+V2jL1iQzMR+zqJCwLz3R6+Lf6AZJfBk9w=,tag:I+GRkL+EBVoSkyXF0Pjx3A==,type:str]
                                 env:
-                                    - name: ENC[AES256_GCM,data:ZmyfzGUn64oenoL8GxSmHow=,iv:jUrkLZnxdu3/qCY4YdT69LhPfgoRViy74lgoqgIR7KQ=,tag:HsZWfugJrpAF3FvHserQ5Q==,type:str]
-                                      value: ENC[AES256_GCM,data:3LVEEPAW/L2Go/e8j+JKMUnLSIc=,iv:1+BcEIyW9NnMkMwR3CVvGgahNUBQv7SeDtZGHs41K4c=,tag:8Hrd6QbvqBHVbt28wX9P3g==,type:str]
-                                    - name: ENC[AES256_GCM,data:+mkpPsHfv+qQop2EUIjvw4Gj7oiW,iv:epl4ZuFvqnCq7YZRXFi/ExzW15r1TI3KCuvDr3fIvqY=,tag:3oTbcnthCmqr2JuicUI00g==,type:str]
-                                      value: ENC[AES256_GCM,data:tgH2JxNBQHyyXZCxYqBeLH2LuumfcbnYd/gKMI+sVLTz81Q7E0UYUQ==,iv:J+S2boki4pTz6y3ThspX5j/XkHW5uSYYQRyXryNJz2o=,tag:+bKJkedJHjs5aMRlgY+Xow==,type:str]
-                                    - name: ENC[AES256_GCM,data:+q+fQSju+m6vuQ==,iv:HJPcz9t+8vhCkptyx+jxeyOiwkecUFDpmB+Ymflo/ZY=,tag:CNdGhdKWQGpQ7GCgCL0reg==,type:str]
-                                      value: ENC[AES256_GCM,data:aku6yCxV7338eA==,iv:MMZtE/cXtWIkBTkOXNFAa2ijEeBvFK72dFtMnSAgGBQ=,tag:xzbeV9nSyuEyHaUe+ox8cQ==,type:str]
+                                    - name: ENC[AES256_GCM,data:7cnTSb1Vi3e1Le+oGBx/jJs=,iv:uGeKEei1yOEAr5sgXoG1kPV5G0s5lmXME5Kcc/xxVF4=,tag:CYcA8k+csjw8oAaDSjaPww==,type:str]
+                                      value: ENC[AES256_GCM,data:KddO+8E82vrBxdUAft0WKnVQ8Gg=,iv:BWW4nrmh2rObYANfoy+lBdcDuBGD3f4E0RKry9rdCnk=,tag:UbC8SV6E5BQJP5mbZbT7Tw==,type:str]
+                                    - name: ENC[AES256_GCM,data:tcCZsH9WnK/CsfGki4zEKBoTf/6V,iv:re6QlCFJtkLuxmpy+ClIAD3vC1T8hYbEO3MnXQxpAyU=,tag:SQH2WWUKgPUuksV5P/3zHg==,type:str]
+                                      value: ENC[AES256_GCM,data:jLgLRZOb2Kvxk1C67cq0ai9/n8uXhGb0nmnNLovPbCLsTUtsGw+2nA==,iv:q32wcwcFJb/VLux2CnAoteyrHQKZZtbnZM0DX9ljmpM=,tag:HNA9doY3779L2cHq/gIg+g==,type:str]
+                                    - name: ENC[AES256_GCM,data:UEQEKi3JFCWoPQ==,iv:JmKnj1G0B5+a0PcAUfjzIDIvShj/LiceN2YCiJg37uQ=,tag:wK0SJkwYJKRX6/TxOLbXtw==,type:str]
+                                      value: ENC[AES256_GCM,data:nodOpQOPH9GLDw==,iv:YEMF8ogDk3ALMIFXhcHxfEEPBUyPO40Tj6n1UPkp6YE=,tag:jOywOzFIRcYft00k9ZhbyA==,type:str]
                 fsm-demo:
                     apiVersion: ENC[AES256_GCM,data:Ojw=,iv:AxmLEfH9qoTgdUFO9HOMk9pY3zYNjm69+vNdf82VuAk=,tag:S0O9BO/tVdrxbRNUD+ovIQ==,type:str]
                     clusters:
@@ -1685,7 +1685,7 @@ sops:
           created_at: "2023-02-28T12:01:59Z"
           enc: AQICAHjEvQaNWs0Zj/laHQzVyaV/OAacQ3AJGQojIvVJeuwcQgFPqRFFenLsn6kwZP4hrDi6AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMAML0lpkMclJWKdhCAgEQgDvyCj9BtaAzaR14cQUoOzd9S8QW5wGB4UmFRJhFhNlWG+hBNAW0hHHizGaq9MLjks2NGuQiYrgtXrbNlQ==
           aws_profile: ""
-    lastmodified: "2026-01-30T10:34:02Z"
-    mac: ENC[AES256_GCM,data:DFUzEuYb4ekMzBz8w2GW4wE5+VbCaRGdUOztFsy91Va4MF6D5HrfLQBWG3ul+txFlrXLHvVIen9q4ktmm9d5GLQMcRmuNWgK3PlBlrMvqXIEwwuwuRT8zrnWLBFPSXwC2mRafNeGPl/a+oz78xA5PRAzXEWGoSAuN+zxpjUeitI=,iv:NuYU/FMo8TdOmzomwCNcRaZpjjR9b+KOwaqdF8fwYaw=,tag:VPHk50go95xisnk362mqjA==,type:str]
+    lastmodified: "2026-02-02T10:04:06Z"
+    mac: ENC[AES256_GCM,data:GO47frnaRDx/E9aTiA8l0wjo2MEPm8XoDD4fHQc1RPL5P6Xo+FYgi3Bf584D7dJqLKBb/166aC30NUMdYeC0RdEac/NSrJHQ/54kqy1cTI2t6q0+SoxEx4NStE9VYGi0ZhIUzQpJIU5f1U3/WPnSsIxPG2yJfwr05rRLyzpdK3c=,iv:cEgNbaLr08h/lhJyc5YcaxcbfHQ3AQPTZENUYFUXy2E=,tag:ZsmTEdbs7P7wFdcbRW88Ww==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2

--- a/deploy-as-code/helm/environments/ci.yaml
+++ b/deploy-as-code/helm/environments/ci.yaml
@@ -61,7 +61,7 @@ jenkins:
         - egovernments*moz-health-prd
         - egovernments*mukta-uat-ifix
         - egovernments*mukta-prod-ifix
-        - egovernments*health-demo-upgrade
+        - egovernments*hcm-demo-new
         - egovernments*fsm-demo
         - egovernments*unified-moz-qa
         - egovernments*hcm-demo
@@ -150,8 +150,8 @@ jenkins:
       acl: [egovernments*unified-mukta-qa]
     - name: moz-health-prd
       acl: [egovernments*moz-health-prd]
-    - name: health-demo-upgrade
-      acl: [egovernments*health-demo-upgrade]
+    - name: hcm-demo-new
+      acl: [egovernments*hcm-demo]
     - name: fsm-demo
       acl: [egovernments*fsm-demo]
     - name: digit-ips


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new deployment target/environment ("hcm-demo-new") and updated CI jobs to deploy from that branch.

* **Chores**
  * Refreshed encrypted secrets and updated SOPS metadata across CI credentials and related configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->