### PR TITLE
feat(helm): add digit-user-preferences-service chart

### DIFF
--- a/deploy-as-code/helm/charts/common-services/digit-user-preferences-service/Chart.yaml
+++ b/deploy-as-code/helm/charts/common-services/digit-user-preferences-service/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: digit-user-preferences-service
+description: User preferences service for storing notification consent and language settings
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+
+dependencies:
+- name: common
+  version: 0.0.5
+  repository: file://../../common

--- a/deploy-as-code/helm/charts/common-services/digit-user-preferences-service/templates/deployment.yaml
+++ b/deploy-as-code/helm/charts/common-services/digit-user-preferences-service/templates/deployment.yaml
@@ -1,0 +1,1 @@
+{{- template "common.deployment" . -}}

--- a/deploy-as-code/helm/charts/common-services/digit-user-preferences-service/templates/ingress.yaml
+++ b/deploy-as-code/helm/charts/common-services/digit-user-preferences-service/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{- template "common.ingress" . -}}

--- a/deploy-as-code/helm/charts/common-services/digit-user-preferences-service/templates/service.yaml
+++ b/deploy-as-code/helm/charts/common-services/digit-user-preferences-service/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- template "common.service" . -}}

--- a/deploy-as-code/helm/charts/common-services/digit-user-preferences-service/values.yaml
+++ b/deploy-as-code/helm/charts/common-services/digit-user-preferences-service/values.yaml
@@ -1,0 +1,75 @@
+# Common Labels
+labels:
+  app: "digit-user-preferences-service"
+  group: "common"
+
+# Ingress Configs
+ingress:
+  enabled: true
+  zuul: true
+  context: "user-preference"
+
+# Init Containers - DB Migration using Flyway
+initContainers:
+  dbMigration:
+    enabled: true
+    schemaTable: "digit_user_preferences_schema"
+    image:
+      repository: "digit-user-preferences-service-db"
+
+# Container Configs
+image:
+  repository: "digit-user-preferences-service"
+replicas: "1"
+httpPort: 8080
+
+# Health Checks
+healthChecks:
+  enabled: true
+  livenessProbePath: "/health"
+  readinessProbePath: "/health"
+
+# Resource allocation for Go service (lighter than Java)
+memory_limits: "256Mi"
+resources: |
+  requests:
+    memory: "64Mi"
+    cpu: "50m"
+  limits:
+    memory: {{ .Values.memory_limits | quote }}
+    cpu: "200m"
+
+# Tracing disabled for Go service (not using Spring/Jaeger by default)
+tracing-enabled: false
+
+# Environment variables
+env: |
+  - name: SERVER_PORT
+    value: "8080"
+  - name: SERVER_CONTEXT_PATH
+    value: "/user-preference"
+  - name: DB_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: egov-config
+        key: db-host
+  - name: DB_PORT
+    value: "5432"
+  - name: DB_NAME
+    value: {{ index .Values "db-name" | quote }}
+  - name: DB_USER
+    valueFrom:
+      secretKeyRef:
+        name: db
+        key: username
+  - name: DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: db
+        key: password
+  - name: DB_SSL_MODE
+    value: {{ index .Values "db-ssl-mode" | quote }}
+
+# Default values (can be overridden in environment files)
+db-name: "digit_user_preferences"
+db-ssl-mode: "disable"

--- a/deploy-as-code/helm/environments/unified-dev.yaml
+++ b/deploy-as-code/helm/environments/unified-dev.yaml
@@ -170,6 +170,7 @@ cluster-configs:
         hcm-abha: "http://hcm-abha:8080/"
         filestore: "http://filestore:8080/"
         template-config: "http://template-config:8080/"
+        digit-user-preferences-service: "http://digit-user-preferences-service.egov:8080/"
 
     sunbird-config:
       data:
@@ -1245,6 +1246,13 @@ loki:
       retention_deletes_enabled: true
       retention_period: 72h  # 3 days
 # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+# User Preferences Service (Go)
+digit-user-preferences-service:
+  replicas: 1
+  db-name: "unifieddevdb"
+  db-ssl-mode: "disable"
+  memory_limits: "256Mi"
 
 
 


### PR DESCRIPTION
- Create Helm chart for Go-based user preferences service
- Configure lightweight resources (256Mi) suitable for Go
- Add DB migration init container with Flyway
- Configure health checks at /health endpoint
- Add service to unified-dev environment with egov namespace
- Register service host in egov-service-host configmap