### PR TITLE
fix(helm): enable SSL for database connection

### DIFF
--- a/deploy-as-code/helm/charts/common-services/digit-user-preferences-service/values.yaml
+++ b/deploy-as-code/helm/charts/common-services/digit-user-preferences-service/values.yaml
@@ -73,4 +73,4 @@ env: |
 
 # Default values (can be overridden in environment files)
 db-name: "digit_user_preferences"
-db-ssl-mode: "disable"
+db-ssl-mode: "require"

--- a/deploy-as-code/helm/environments/unified-dev.yaml
+++ b/deploy-as-code/helm/environments/unified-dev.yaml
@@ -1251,7 +1251,7 @@ loki:
 digit-user-preferences-service:
   replicas: 1
   db-name: "unifieddevdb"
-  db-ssl-mode: "disable"
+  db-ssl-mode: "require"
   memory_limits: "256Mi"
 
 


### PR DESCRIPTION
RDS PostgreSQL requires SSL encryption. Change db-ssl-mode from "disable" to "require" for secure database connections.