### PR TITLE
Addition of OTEL configuration properties for 2.9.2 tracer upgrade

### DIFF
--- a/deploy-as-code/helm/charts/digit-works/backend/attendance/values.yaml
+++ b/deploy-as-code/helm/charts/digit-works/backend/attendance/values.yaml
@@ -90,6 +90,12 @@ env: |
     value: "save-attendee"
   - name: ATTENDANCE_ATTENDEE_KAFKA_UPDATE_TOPIC
     value: "update-attendee"
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: SPRING_REDIS_HOST
     value: redis.backbone
   - name: SPRING_REDIS_PORT

--- a/deploy-as-code/helm/charts/digit-works/backend/expense-calculator/values.yaml
+++ b/deploy-as-code/helm/charts/digit-works/backend/expense-calculator/values.yaml
@@ -80,6 +80,12 @@ env: |
       configMapKeyRef:
         name: egov-service-host
         key: egov-mdms-service-v2
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: EGOV_MDMS_SEARCH_ENDPOINT
     value: "egov-mdms-service/v1/_search"      
   - name: EGOV_IDGEN_HOST

--- a/deploy-as-code/helm/charts/digit-works/backend/expense/values.yaml
+++ b/deploy-as-code/helm/charts/digit-works/backend/expense/values.yaml
@@ -109,6 +109,12 @@ env: |
       configMapKeyRef:
         name: egov-service-host
         key: individual
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: BUSINESS_WORKFLOW_STATUS_MAP
     value: {{ index .Values "business-workflow-status-map" | quote }}
   - name: EXPENSE_BILLING_BILL_CREATE

--- a/deploy-as-code/helm/charts/digit-works/backend/muster-roll/values.yaml
+++ b/deploy-as-code/helm/charts/digit-works/backend/muster-roll/values.yaml
@@ -109,6 +109,12 @@ env: |
       configMapKeyRef:
         name: egov-config
         key: timezone
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: MUSTERROLL_KAFKA_CREATE_TOPIC
     value: "save-musterroll"
   - name: MUSTERROLL_KAFKA_UPDATE_TOPIC

--- a/deploy-as-code/helm/charts/health-services/beneficiary-idgen/values.yaml
+++ b/deploy-as-code/helm/charts/health-services/beneficiary-idgen/values.yaml
@@ -70,6 +70,12 @@ env: |
     value: "false"  
   - name: MANAGEMENT_SECURITY_ENABLED
     value: "false" 
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: SPRING_REDIS_HOST
     value: redis.backbone
   - name: SPRING_REDIS_PORT

--- a/deploy-as-code/helm/charts/health-services/census-service/values.yaml
+++ b/deploy-as-code/helm/charts/health-services/census-service/values.yaml
@@ -77,6 +77,12 @@ env: |
     value: {{ index .Values "heap" | quote }}
   - name: JAVA_ARGS
     value: {{ index .Values "java-args" | quote }}
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: SERVER_PORT
     value: "8080"
   - name: SECURITY_BASIC_ENABLED

--- a/deploy-as-code/helm/charts/health-services/excel-ingestion/values.yaml
+++ b/deploy-as-code/helm/charts/health-services/excel-ingestion/values.yaml
@@ -103,6 +103,12 @@ env: |
   - name: EGOV_MDMS_SEARCH_PATH
     value: {{ index .Values "egov-mdms-service-endpoint-key" | quote }}
 
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: DEFAULT_LOCALE
     value: {{ index .Values "defaultLocale" | quote }}
   - name: MANAGEMENT_HEALTH_REDIS_ENABLED

--- a/deploy-as-code/helm/charts/health-services/facility/values.yaml
+++ b/deploy-as-code/helm/charts/health-services/facility/values.yaml
@@ -82,6 +82,12 @@ env: |
   - name: MANAGEMENT_SECURITY_ENABLED
     value: "false"
   
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"  
   - name: FACILITY.KAFKA.CREATE.TOPIC
     value: "save-facility-health-topic"
   - name: FACILITY.KAFKA.UPDATE.TOPIC

--- a/deploy-as-code/helm/charts/health-services/health-individual/values.yaml
+++ b/deploy-as-code/helm/charts/health-services/health-individual/values.yaml
@@ -106,6 +106,12 @@ env: |
     value: "egov.core.notification.sms"
   - name: INDIVIDUAL.PRODUCER.SAVE.ABHATRANSACTION.TOPIC 
     value: "save-abha-transaction-health-topic"
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: STATE_LEVEL_TENANT_ID
     valueFrom:
       configMapKeyRef:

--- a/deploy-as-code/helm/charts/health-services/health-project/values.yaml
+++ b/deploy-as-code/helm/charts/health-services/health-project/values.yaml
@@ -78,6 +78,12 @@ env: |
     value: "60"
   - name: SPRING_CACHE_AUTOEXPIRY
     value: "true"
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: JAVA_OPTS
     value: {{ index .Values "heap" | quote }}
   - name: JAVA_ARGS

--- a/deploy-as-code/helm/charts/health-services/health-service-request/values.yaml
+++ b/deploy-as-code/helm/charts/health-services/health-service-request/values.yaml
@@ -63,6 +63,12 @@ env: |
     value: "8192"
   - name: JAVA_OPTS
     value: {{ index .Values "heap" | quote }}
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: SERVER_PORT
     value: "8080"
   - name: JAVA_ARGS

--- a/deploy-as-code/helm/charts/health-services/household/values.yaml
+++ b/deploy-as-code/helm/charts/health-services/household/values.yaml
@@ -88,6 +88,12 @@ env: |
     value: "8080"
   - name: SECURITY_BASIC_ENABLED
     value: "false"
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: EGOV_INDIVIDUAL_HOST
     valueFrom:
       configMapKeyRef:

--- a/deploy-as-code/helm/charts/health-services/plan-service/values.yaml
+++ b/deploy-as-code/helm/charts/health-services/plan-service/values.yaml
@@ -95,6 +95,12 @@ env: |
       configMapKeyRef:
         name: egov-service-host
         key: census-service
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: WORKFLOW_INITIATE_ACTION
     value: "INITIATE"
   - name: WORKFLOW_INTERMEDIATE_ACTION

--- a/deploy-as-code/helm/charts/health-services/product/values.yaml
+++ b/deploy-as-code/helm/charts/health-services/product/values.yaml
@@ -73,6 +73,12 @@ env: |
     value: {{ index .Values "heap" | quote }}
   - name: JAVA_ARGS
     value: {{ index .Values "java-args" | quote }}
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: SERVER_PORT
     value: "8080"
   - name: SECURITY_BASIC_ENABLED

--- a/deploy-as-code/helm/charts/health-services/referralmanagement/values.yaml
+++ b/deploy-as-code/helm/charts/health-services/referralmanagement/values.yaml
@@ -212,6 +212,12 @@ env: |
         key: facility
   - name: EGOV_SEARCH_FACILITY_URL
     value: "/facility/v1/_search"
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: PROJECT_MDMS_MODULE
     value: "HCM-PROJECT-TYPES"
   - name: EGOV_LOCATION_HIERARCHY_TYPE

--- a/deploy-as-code/helm/charts/health-services/resource-generator/values.yaml
+++ b/deploy-as-code/helm/charts/health-services/resource-generator/values.yaml
@@ -105,6 +105,12 @@ env: |
     value: "resource-microplan-create-topic"
   - name: INTEGRATE_WITH_ADMIN_CONSOLE
     value: "true"
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: DEFAULT_LIMIT_FOR_MDMS_DATA
     value: "20"
   - name: ENABLE_LOCK_ON_PLAN_ESTIMATION_SHEET

--- a/deploy-as-code/helm/charts/health-services/stock/values.yaml
+++ b/deploy-as-code/helm/charts/health-services/stock/values.yaml
@@ -153,6 +153,12 @@ env: |
         key: {{ index .Values "egov-mdms-service-host-key" | quote }}
   - name: EGOV_MDMS_SEARCH_ENDPOINT
     value: {{ index .Values "egov-mdms-service-endpoint-key" | quote }}
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: EGOV_MDMS_MASTER_NAME
     value: ""
   - name: EGOV_MDMS_MODULE_NAME

--- a/deploy-as-code/helm/charts/health-services/transformer/values.yaml
+++ b/deploy-as-code/helm/charts/health-services/transformer/values.yaml
@@ -77,6 +77,12 @@ env: |
   - name: TRANSFORMER_CONSUMER_CREATE_PROJECT_TOPIC
     value: "save-project-health"
 
+  - name: OTEL_TRACES_EXPORTER
+    value: "none"
+  - name: OTEL_LOGS_EXPORTER
+    value: "none"
+  - name: OTEL_METRICS_EXPORTER
+    value: "none"
   - name: TRANSFORMER_CONSUMER_UPDATE_PROJECT_TOPIC
     value: "update-project-health"
   - name: EGOV_PROJECT_HOST


### PR DESCRIPTION
Addition of OTEL configuration properties for 2.9.2 tracer depending services in health-campaign-services and DIGTI-WORKS (attendance, musterRoll, expense and expense-calculator) services.