### PR TITLE
ci: add InfraScan IaC security and cost audit workflow

### DIFF
--- a/.github/workflows/infrascan-ci.yml
+++ b/.github/workflows/infrascan-ci.yml
@@ -1,0 +1,32 @@
+name: InfraScan Audit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  infrascan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Reports Directory
+        run: |
+          mkdir -p infrascan-reports
+          chmod 777 infrascan-reports
+
+      - name: Run InfraScan
+        uses: soldevelo/infrascan@v1.0.5
+        with:
+          scanner: comprehensive
+          format: html
+          out: infrascan-reports/report.html
+            
+      - name: Upload InfraScan Report
+        uses: actions/upload-artifact@v4
+        if: always() # Upload report even if the scan step fails
+        with:
+          name: infrascan-report
+          path: infrascan-reports/report.html
+          retention-days: 14

--- a/.github/workflows/infrascan-ci.yml
+++ b/.github/workflows/infrascan-ci.yml
@@ -17,7 +17,7 @@ jobs:
           chmod 777 infrascan-reports
 
       - name: Run InfraScan
-        uses: soldevelo/infrascan@v1.0.5
+        uses: soldevelo/infrascan@v1.0.6
         with:
           scanner: comprehensive
           format: html


### PR DESCRIPTION
### Description
This Pull Request follows up on the proposal in #4428. It introduces a GitHub Actions workflow that automatically scans the repository's Infrastructure as Code (Terraform, Kubernetes manifests) for cost optimization opportunities and security misconfigurations using [InfraScan](https://github.com/SolDevelo/InfraScan).

### Key Features
* **Non-blocking (Advisory mode):** This workflow will **not** fail the pipeline or block PR merges, regardless of what it finds. It runs fully asynchronously alongside your existing CI.
* **Actionable Reports:** After every run, it generates an interactive HTML report (`infrascan-report.html`) safely packed into a `.zip` artifact.
* **No Cloud Credentials Needed:** The scanner operates purely on the static IaC code and does not require AWS/cloud keys.

### How to use it
Once merged, contributors can simply click on the **Actions** tab for their Pull Request, select the **InfraScan Audit** job, and scroll down to the **Artifacts** section to download and view the security & cost footprint.

### Related Issue
Addresses/Follows up on: #4428 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated infrastructure scanning on every push and pull request.
  * Generates an HTML scan report and uploads it as a build artifact.
  * Scan reports are retained for 14 days.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/egovernments/DIGIT-DevOps/pull/4441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->