### PR TITLE
Configure xstate-chatbot to use separate Flyway schema table for urba…

### DIFF
--- a/deploy-as-code/helm/charts/core-services/xstate-chatbot/values.yaml
+++ b/deploy-as-code/helm/charts/core-services/xstate-chatbot/values.yaml
@@ -26,7 +26,7 @@ ingress:
 initContainers:
   dbMigration:
     enabled: true
-    schemaTable: "xstate_chatbot_schema"
+    schemaTable: "xstate_chatbot_urban_schema"
     image:
       repository: "xstate-chatbot-db"
 

--- a/deploy-as-code/helm/environments/unified-urban-dev.yaml
+++ b/deploy-as-code/helm/environments/unified-urban-dev.yaml
@@ -273,6 +273,9 @@ xstate-chatbot:
   replicas: 1
   heap: "-Xmx256m -Xms256m"
   memory_limits: "512Mi"
+  initContainers:
+    dbMigration:
+      schemaTable: "xstate_chatbot_urban_schema"  # Separate migration tracking for urban namespace
   whatsapp-provider: "Twilio"
   contact-card-whatsapp-number: "+919880900990"
   contact-card-whatsapp-name: "mSeva Punjab"

--- a/deploy-as-code/helm/environments/unified-urban-dev.yaml
+++ b/deploy-as-code/helm/environments/unified-urban-dev.yaml
@@ -273,9 +273,6 @@ xstate-chatbot:
   replicas: 1
   heap: "-Xmx256m -Xms256m"
   memory_limits: "512Mi"
-  initContainers:
-    dbMigration:
-      schemaTable: "xstate_chatbot_urban_schema"  # Separate migration tracking for urban namespace
   whatsapp-provider: "Twilio"
   contact-card-whatsapp-number: "+919880900990"
   contact-card-whatsapp-name: "mSeva Punjab"


### PR DESCRIPTION
…n namespace

- Added schemaTable: 'xstate_chatbot_urban_schema' configuration
- This prevents migration conflicts between egov and urban namespaces
- Each namespace now maintains its own independent migration history
- No application code changes required - only affects Flyway tracking
- Resolves deployment failures due to migration validation errors

This ensures clean separation of concerns between namespaces and allows independent version deployments without migration conflicts.