### PR TITLE
Fix memory_limits value in unified-health-dev.yaml

### DIFF
--- a/deploy-as-code/helm/environments/unified-health-dev.yaml
+++ b/deploy-as-code/helm/environments/unified-health-dev.yaml
@@ -754,7 +754,6 @@ excel-ingestion:
   central-instance-enabled: false
   cpu_requests: 50m
   memory_limits: 3Gi
-  memory_limits: 1Gi
   excel-ingestion-generation-init-topic: "excel-ingestion-generation-init"
 
 transformer:


### PR DESCRIPTION
Corrected memory_limits value from 1Gi to 3Gi.