### PR TITLE
feat(helm): add schema-registry service chart and digit-lts env.

### DIFF
--- a/deploy-as-code/helm/charts/core-services/schema-registry/Chart.yaml
+++ b/deploy-as-code/helm/charts/core-services/schema-registry/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: schema-registry
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: 0.1.0
+
+dependencies:
+- name: common
+  version: 0.0.5
+  repository: file://../../common

--- a/deploy-as-code/helm/charts/core-services/schema-registry/templates/deployment.yaml
+++ b/deploy-as-code/helm/charts/core-services/schema-registry/templates/deployment.yaml
@@ -1,0 +1,1 @@
+{{- template "common.deployment" . -}}

--- a/deploy-as-code/helm/charts/core-services/schema-registry/templates/ingress.yaml
+++ b/deploy-as-code/helm/charts/core-services/schema-registry/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{- template "common.ingress" . -}}

--- a/deploy-as-code/helm/charts/core-services/schema-registry/templates/service.yaml
+++ b/deploy-as-code/helm/charts/core-services/schema-registry/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- template "common.service" . -}}

--- a/deploy-as-code/helm/charts/core-services/schema-registry/values.yaml
+++ b/deploy-as-code/helm/charts/core-services/schema-registry/values.yaml
@@ -1,0 +1,61 @@
+# Common Labels
+labels:
+  app: "schema-registry"
+  group: "rainmaker"
+
+# Ingress Configs
+ingress:
+  enabled: true
+  zuul: true
+  context: "schema"
+
+# Init Containers Configs
+initContainers:
+  dbMigration:
+    enabled: true
+    schemaTable: "schema_registry_schema"
+    image:
+      repository: "schema-registry-db"
+
+# Container Configs
+image:
+  repository: "schema-registry"
+replicas: "1"
+appType: "java-spring"
+heap: "-Xmx1012m -Xms512m"
+memory_limits: 1500Mi
+memory_requests: 768Mi
+healthChecks:
+  enabled: true
+  livenessProbePath: "/schema/health"
+  readinessProbePath: "/schema/health"
+
+# Additional Container Envs
+env: |
+  - name: SERVER_PORT
+    value: "8080"
+  - name: DB_PORT
+    value: "5432"
+  - name: DB_NAME
+    value: "postgres"
+  - name: DB_USER
+    valueFrom:
+      secretKeyRef:
+        key: username
+        name: db
+  - name: DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        key: password
+        name: db
+  - name: DB_DATASOURCE_URL
+    valueFrom:
+      configMapKeyRef:
+        key: db-url
+        name: egov-config
+  - name: REDIS_HOST
+    value: "redis.backbone"
+  - name: REDIS_PORT
+    value: "6379"
+  - name: JAVA_OPTS
+    value: {{ index .Values "heap" | quote }}

--- a/deploy-as-code/helm/environments/digit-lts.yaml
+++ b/deploy-as-code/helm/environments/digit-lts.yaml
@@ -175,6 +175,7 @@ cluster-configs:
                 registry: "http://registry:8080/"
                 otp: "http://otp.egov:8080/"
                 pdf-v3: "http://pdf-v3.egov:8080/"
+                schema-registry: "http://schema-registry.egov:8080/"
                 license-certificate: "http://license-certificate.egov:8080/"
                 license-citizen: "http://license-citizen.egov:8080/"
                 license-admin: "http://license-admin.egov:8080/"


### PR DESCRIPTION
- Create schema-registry Helm chart in core-services with context path /schema
- Configure PostgreSQL and Redis environment variables in values.yaml
- Add schema-registry URL to egov-service-host in digit-lts.yaml