### PR TITLE
fix: studio-hrms context path left over from studio-egov-hrms rename

### DIFF
--- a/deploy-as-code/helm/charts/studio-services/studio-hrms/values.yaml
+++ b/deploy-as-code/helm/charts/studio-services/studio-hrms/values.yaml
@@ -11,7 +11,7 @@ ingress:
   namespace: egov
   enabled: true
   zuul: true
-  context: "studio-egov-hrms"
+  context: "studio-hrms"
 
 # Init Containers Configs
 initContainers:
@@ -35,8 +35,8 @@ image:
 replicas: "1"
 healthChecks:
   enabled: true
-  livenessProbePath: "/studio-egov-hrms/health"
-  readinessProbePath: "/studio-egov-hrms/health"
+  livenessProbePath: "/studio-hrms/health"
+  readinessProbePath: "/studio-hrms/health"
 appType: "java-spring"
 tracing-enabled: true
 employee-applink: "https://egov-micro-dev.egovernments.org/employee/user/login"
@@ -47,6 +47,8 @@ cpu_limits: "200m"
 
 # Additional Container Envs
 env: |
+  - name: SERVER_SERVLET_CONTEXT_PATH
+    value: "/studio-hrms"
   - name: EGOV_SERVICES_DATA_SYNC_EMPLOYEE_REQUIRED
     value:  "false"
   - name: EGOV_MDMS_HOST


### PR DESCRIPTION
The rename to studio-hrms updated the chart/image name but missed the ingress context and health-check paths, and never set SERVER_SERVLET_CONTEXT_PATH at all. Without that env var the jar falls back to its hardcoded /egov-hrms context path, so liveness/readiness probes against /studio-hrms/health would have failed regardless of the image fix.