### PR TITLE
ci: auto-merge build tag bumps on unified-env-lts

### DIFF
--- a/.github/scripts/validate_tag_bump.py
+++ b/.github/scripts/validate_tag_bump.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Gate for the tag-bump auto-merge workflow.
+
+Compares each given env file between the PR base and the PR head and
+requires that the only differences are scalar values at a path ending in
+image.tag or image.repository (at any nesting depth, e.g. also under
+initContainers.<name>.image.*) for service keys that already existed on
+the base. Any added/removed key, or a change anywhere else, marks the PR
+unsafe to auto-merge and leaves it for a human/code-owner review instead.
+"""
+import argparse
+import os
+import subprocess
+import sys
+
+import yaml
+
+ALLOWED_LEAF_SUFFIXES = (("image", "tag"), ("image", "repository"))
+
+
+def load_ref_file(ref, path):
+    try:
+        content = subprocess.check_output(["git", "show", f"{ref}:{path}"], text=True)
+    except subprocess.CalledProcessError:
+        return None
+    return yaml.safe_load(content) or {}
+
+
+def load_file(path):
+    if not os.path.exists(path):
+        return {}
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def leaf_is_allowed(path_tuple):
+    return len(path_tuple) >= 2 and path_tuple[-2:] in ALLOWED_LEAF_SUFFIXES
+
+
+def diff_dicts(old, new, path=()):
+    old = old if isinstance(old, dict) else old
+    new = new if isinstance(new, dict) else new
+
+    if not isinstance(old, dict) or not isinstance(new, dict):
+        if old == new:
+            return True, []
+        if leaf_is_allowed(path) and isinstance(new, (str, int, float)):
+            return True, []
+        return False, [f"disallowed change at {'.'.join(path) or '<root>'}"]
+
+    old_keys, new_keys = set(old.keys()), set(new.keys())
+    added, removed = new_keys - old_keys, old_keys - new_keys
+    reasons = []
+    if added:
+        reasons.append(f"new key(s) added at {'.'.join(path) or '<root>'}: {sorted(added)}")
+    if removed:
+        reasons.append(f"key(s) removed at {'.'.join(path) or '<root>'}: {sorted(removed)}")
+    if reasons:
+        return False, reasons
+
+    ok, all_reasons = True, []
+    for k in old_keys:
+        sub_ok, sub_reasons = diff_dicts(old[k], new[k], path + (str(k),))
+        if not sub_ok:
+            ok = False
+            all_reasons.extend(sub_reasons)
+    return ok, all_reasons
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--base", required=True)
+    p.add_argument("--files", nargs="+", required=True)
+    args = p.parse_args()
+
+    all_ok = True
+    for path in args.files:
+        old = load_ref_file(args.base, path)
+        if old is None:
+            print(f"{path}: not present on base ref -> treating as unsafe")
+            all_ok = False
+            continue
+        new = load_file(path)
+        ok, reasons = diff_dicts(old, new)
+        if ok:
+            print(f"{path}: OK (no changes, or tag/repository-only changes)")
+        else:
+            all_ok = False
+            print(f"{path}: DISALLOWED changes:")
+            for r in reasons:
+                print(f"  - {r}")
+
+    gh_output = os.environ.get("GITHUB_OUTPUT")
+    if gh_output:
+        with open(gh_output, "a") as f:
+            f.write(f"safe={'true' if all_ok else 'false'}\n")
+
+    print(f"\nResult: {'SAFE to auto-merge' if all_ok else 'NOT safe -- leaving for human review'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/auto-merge-tag-bumps.yml
+++ b/.github/workflows/auto-merge-tag-bumps.yml
@@ -1,0 +1,96 @@
+name: Auto-merge build tag bumps (unified-env-lts)
+
+# Fast-lane for build-tag bumps: this repo's branch protection on
+# unified-env-lts requires an approving review from a CODEOWNERS entry.
+# For the narrow case of "bump image.tag/image.repository in one of the
+# allowlisted env files, nothing else," this workflow validates the diff
+# is exactly that and, if so, approves (using a code owner's token) and
+# merges automatically. Any PR that touches anything else -- a different
+# file, a *-secrets.yaml file, a new/removed key, non-tag config -- is
+# left untouched for normal human review.
+
+on:
+  pull_request:
+    branches: [unified-env-lts]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "deploy-as-code/helm/environments/unified-dev.yaml"
+      - "deploy-as-code/helm/environments/unified-qa.yaml"
+      - "deploy-as-code/helm/environments/unified-uat.yaml"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate-and-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Fetch base ref
+        run: git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
+
+      - name: Reject if any non-allowlisted file changed
+        id: files
+        run: |
+          ALLOWED_FILES="deploy-as-code/helm/environments/unified-dev.yaml
+          deploy-as-code/helm/environments/unified-qa.yaml
+          deploy-as-code/helm/environments/unified-uat.yaml"
+          CHANGED=$(git diff --name-only "origin/${{ github.event.pull_request.base.ref }}" HEAD)
+          echo "Changed files:"
+          echo "$CHANGED"
+          safe=true
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            if ! grep -qxF "$f" <<< "$ALLOWED_FILES"; then
+              echo "Disallowed file changed: $f"
+              safe=false
+            fi
+          done <<< "$CHANGED"
+          echo "safe=$safe" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        if: steps.files.outputs.safe == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install pyyaml
+        if: steps.files.outputs.safe == 'true'
+        run: pip install pyyaml
+
+      - name: Validate diff is tag/repository-only
+        if: steps.files.outputs.safe == 'true'
+        id: diffcheck
+        run: |
+          python3 .github/scripts/validate_tag_bump.py \
+            --base "origin/${{ github.event.pull_request.base.ref }}" \
+            --files \
+              deploy-as-code/helm/environments/unified-dev.yaml \
+              deploy-as-code/helm/environments/unified-qa.yaml \
+              deploy-as-code/helm/environments/unified-uat.yaml
+
+      - name: Approve PR
+        if: steps.diffcheck.outputs.safe == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CODEOWNER_APPROVAL_TOKEN }}
+        run: |
+          gh pr review "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --approve \
+            --body "Auto-approved: PR contains only image.tag/image.repository changes in an allowlisted env file. See .github/workflows/auto-merge-tag-bumps.yml."
+
+      - name: Merge PR
+        if: steps.diffcheck.outputs.safe == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CODEOWNER_APPROVAL_TOKEN }}
+        run: |
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --squash


### PR DESCRIPTION
## Why
Every PR to `unified-env-lts` needs a CODEOWNERS approval (repo-wide, no path scoping). For the common release-day case — bump `image.tag`/`image.repository` for one service in `unified-dev.yaml`/`unified-qa.yaml`/`unified-uat.yaml`, nothing else — that's pure latency with no real review value, since the change is mechanical and low-risk.

## What this adds
`.github/workflows/auto-merge-tag-bumps.yml` + `.github/scripts/validate_tag_bump.py`:
- Triggers only on PRs touching `unified-dev.yaml` / `unified-qa.yaml` / `unified-uat.yaml`
- Structurally diffs old vs new YAML (not a line/regex match) and requires every change to be a scalar value at a path ending in `image.tag` or `image.repository` — no added/removed keys anywhere, no other field touched
- If (and only if) that holds, uses a code owner's PAT to approve + squash-merge; anything broader (new file, `*-secrets.yaml`, unrelated field, structural change) is left untouched for normal review

Tested locally against a safe tag-bump diff, an injected new key, and an unrelated-field change — the first passes, the other two are correctly rejected.

## Before this is functional
Add a **fine-grained PAT** (scoped to this repo only, `Pull requests: Read and write` + `Contents: Read and write`) from one of the CODEOWNERS (@nikhilmulinti-egov) as a repo secret named `CODEOWNER_APPROVAL_TOKEN`. Until that secret exists, the approve/merge steps simply fail closed — PRs still route to normal human review, nothing bypasses silently.