### PR TITLE
test: auto-merge bot verification (kafka-connect tag bump)

### DIFF
--- a/deploy-as-code/helm/environments/unified-dev.yaml
+++ b/deploy-as-code/helm/environments/unified-dev.yaml
@@ -1285,7 +1285,7 @@ kafka-v2:
 ### Kafka Connect <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 kafka-connect:
   image:
-    tag: "5.4.1"  
+    tag: "5.4.1-automerge-bot-test"  
 
 
 # zookeeper-v2 AWS >>>>>>>>>>>>>>>>>>>>>>>>>>>>>


### PR DESCRIPTION
Testing the auto-merge-tag-bumps workflow end to end. Should be auto-approved and squash-merged if the bot is working. kafka-connect has no live ArgoCD Application/ApplicationSet on unified-dev yet, so this is inert on the cluster side.