### PR TITLE
test: revert kafka-connect tag back to 5.4.1

### DIFF
--- a/deploy-as-code/helm/environments/unified-dev.yaml
+++ b/deploy-as-code/helm/environments/unified-dev.yaml
@@ -1285,7 +1285,7 @@ kafka-v2:
 ### Kafka Connect <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 kafka-connect:
   image:
-    tag: "5.4.1-automerge-bot-test"  
+    tag: "5.4.1"  
 
 
 # zookeeper-v2 AWS >>>>>>>>>>>>>>>>>>>>>>>>>>>>>


### PR DESCRIPTION
Cleanup after auto-merge-bot test PR #4777. Restores the original value.