### PR TITLE
Declare github-config secret and set auto-escalation UUID for studio UAT

### DIFF
--- a/deploy-as-code/helm/environments/unified-studio-uat.yaml
+++ b/deploy-as-code/helm/environments/unified-studio-uat.yaml
@@ -166,9 +166,12 @@ cluster-configs:
               studio-pdf-helper-service: "http://studio-pdf-helper-service.studio:8080/"
     
     secrets:
-      db: 
+      db:
         namespace: [ studio ]
         name: db
+      github-config:
+        namespace: [ studio ]
+        name: github-config
 
 
 digit-studio:
@@ -191,7 +194,8 @@ public-service:
   mdms-service-host: "http://mdms-v2.egov:8080/"
   mdms-v2-update-endpoint: "egov-mdms-service/v2/_update"
   namespace: studio
-  
+  auto-escalation-system-user-uuid: "ff1381dd-f8ad-41f5-ac73-24ebc0130cf6"
+
 public-service-init:
   replicas: 1
   heap: "-Xmx512m -Xms256m"


### PR DESCRIPTION
Add missing github-config secret declaration (studio-pdf-helper-service needs it; actual encrypted values to be added by DevOps to unified-studio-uat-secrets.yaml), and set auto-escalation-system-user-uuid on public-service, matching per-environment config already present in dev.