### PR TITLE
fix(studio-user-otp): widen liveness/readiness probe timeouts for slo…

### DIFF
--- a/deploy-as-code/helm/charts/studio-services/studio-user-otp/values.yaml
+++ b/deploy-as-code/helm/charts/studio-services/studio-user-otp/values.yaml
@@ -30,6 +30,24 @@ healthChecks:
   enabled: true
   livenessProbePath: "/studio-user-otp/health"
   readinessProbePath: "/studio-user-otp/health"
+  livenessProbe: |
+      httpGet:
+          path: "{{ .Values.healthChecks.livenessProbePath }}"
+          port: {{ default .Values.httpPort .Values.healthPort }}
+      initialDelaySeconds: 60
+      timeoutSeconds: 15
+      periodSeconds: 30
+      successThreshold: 1
+      failureThreshold: 12
+  readinessProbe: |
+      httpGet:
+          path: "{{ .Values.healthChecks.readinessProbePath }}"
+          port: {{ default .Values.httpPort .Values.healthPort }}
+      initialDelaySeconds: 60
+      timeoutSeconds: 15
+      periodSeconds: 30
+      successThreshold: 1
+      failureThreshold: 12
 replicas: "1"
 appType: "java-spring"
 tracing-enabled: true


### PR DESCRIPTION
…w JVM boot

Pod was crash-looping — liveness probe's tight defaults (30s initial delay, 3s timeout, 5x failure threshold) kill the container before Spring Boot finishes starting under the chart's 200m CPU limit (observed boot >3.5min, one contributor to /health alone taking 11.5s). Widen to 60s initial delay, 15s timeout, 30s period, 12x failure threshold (~6.5min grace) so the pod survives its own slow startup. Does not fix the underlying CPU-limit cause.