### PR TITLE
feat(studio): wire BOUNDARY_SERVICE_HOST for public-service boundaryC…

### DIFF
--- a/deploy-as-code/helm/charts/studio-services/public-service/values.yaml
+++ b/deploy-as-code/helm/charts/studio-services/public-service/values.yaml
@@ -96,6 +96,13 @@ env: |
     value: "studio-individual/v1/_update"
   - name: INDIVIDUAL_SEARCH_ENDPOINT
     value: "studio-individual/v1/_search"
+  - name: BOUNDARY_SERVICE_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: egov-service-host
+        key: boundary-service
+  - name: BOUNDARY_SEARCH_ENDPOINT
+    value: "boundary-service/boundary/_search"
   - name: MDMS_SERVICE_HOST
     value: {{ index .Values "mdms-service-host" | quote }}
   - name: MDMS_SEARCH_ENDPOINT 

--- a/deploy-as-code/helm/environments/unified-studio-dev.yaml
+++ b/deploy-as-code/helm/environments/unified-studio-dev.yaml
@@ -214,9 +214,9 @@ public-service:
   initContainers:
     dbMigration:
       image:
-        tag: "studio-dynamic-dashboard-backend-df83606"
+        tag: "studio-dynamic-dashboard-backend-21f223a"
   image:
-    tag: "studio-dynamic-dashboard-backend-df83606"
+    tag: "studio-dynamic-dashboard-backend-21f223a"
   replicas: 1
   namespace: studio
   heap: '-Xmx256m -Xms118m'


### PR DESCRIPTION
…ode validation

public-service now validates address.boundaryCode against boundary-service on create/update (CCSD-1389); adds the host/endpoint env vars, reusing the existing boundary-service key in the egov-service-host configmap.